### PR TITLE
Faster docker builds & docker-compose.yml with build info (#6)

### DIFF
--- a/.github/workflows/dockerhub-testnet.yml
+++ b/.github/workflows/dockerhub-testnet.yml
@@ -23,28 +23,35 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           install: true
-      - name: Log in to GitHub
-        if: startsWith(github.ref, 'refs/heads/')
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Login to GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to DockerHub
-        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: DockerHub Build
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Docker Build
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v3
         with:
           context: .
           file: utils/docker/Dockerfile
+          cache-to: ghcr.io/letheanvpn/blockchain-itw3:testnet-${{ github.ref_name }}
+          cache-from: ghcr.io/letheanvpn/blockchain-itw3:testnet-${{ github.ref_name }}
           push: true
-          tags: lthn/chain-itw3:testnet
-      - name: GitHub Build
-        if: startsWith(github.ref, 'refs/heads/')
+          tags: lthn/chain:testnet-${{ github.ref_name }},ghcr.io/letheanvpn/blockchain-itw3:testnet-${{ github.ref_name }}
+      - name: Docker Build
+        if: ${{ github.event_name == 'pull_request' }}
         uses: docker/build-push-action@v3
         with:
           context: .
           file: utils/docker/Dockerfile
+          cache-to: ghcr.io/letheanvpn/blockchain-itw3:testnet-${{ github.head_ref }}
+          cache-from: ghcr.io/letheanvpn/blockchain-itw3:testnet-${{ github.head_ref }}
           push: true
-          tags: ghcr.io/letheanvpn/blockchain-itw3:testnet
+          tags: lthn/chain:testnet-${{ github.head_ref }},ghcr.io/letheanvpn/blockchain-itw3:testnet-${{ github.head_ref }}
+

--- a/.idea/runConfigurations/daemon.xml
+++ b/.idea/runConfigurations/daemon.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="daemon" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--data-dir $ProjectFileDir$" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$ProjectFileDir$" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Lethean" TARGET_NAME="daemon" CONFIG_NAME="Debug-gcc" RUN_TARGET_PROJECT_NAME="Lethean" RUN_TARGET_NAME="daemon">
+  <configuration default="false" name="daemon" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--data-dir $ProjectFileDir$" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$ProjectFileDir$" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Lethean" TARGET_NAME="daemon" CONFIG_NAME="Release" RUN_TARGET_PROJECT_NAME="Lethean" RUN_TARGET_NAME="daemon">
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
     </method>

--- a/.idea/runConfigurations/docker_server.xml
+++ b/.idea/runConfigurations/docker_server.xml
@@ -3,7 +3,7 @@
     <deployment type="dockerfile">
       <settings>
         <option name="imageTag" value="lthn/chain-itw3:testnet" />
-        <option name="buildCliOptions" value="--platform linux/x86_64" />
+        <option name="buildCliOptions" value="--platform linux/x86_64 --build-arg THREADS=4" />
         <option name="buildKitEnabled" value="true" />
         <option name="containerName" value="" />
         <option name="contextFolderPath" value="." />

--- a/.idea/runConfigurations/simplewallet.xml
+++ b/.idea/runConfigurations/simplewallet.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="simplewallet" type="CMakeRunConfiguration" factoryName="Application" singleton="false" PROGRAM_PARAMS="--wallet-file test" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$CMakeCurrentLocalGenerationDir$" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Lethean" TARGET_NAME="simplewallet" CONFIG_NAME="Debug-gcc" RUN_TARGET_PROJECT_NAME="Lethean" RUN_TARGET_NAME="simplewallet">
+  <configuration default="false" name="simplewallet" type="CMakeRunConfiguration" factoryName="Application" singleton="false" PROGRAM_PARAMS="--wallet-file test" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$CMakeCurrentLocalGenerationDir$" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Lethean" TARGET_NAME="simplewallet" CONFIG_NAME="Release" RUN_TARGET_PROJECT_NAME="Lethean" RUN_TARGET_NAME="simplewallet">
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
     </method>

--- a/.idea/runConfigurations/wallet.xml
+++ b/.idea/runConfigurations/wallet.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="wallet" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--generate-new-wallet test" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$CMakeCurrentLocalGenerationDir$" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Lethean" TARGET_NAME="wallet" CONFIG_NAME="Debug-gcc" RUN_TARGET_PROJECT_NAME="Lethean" RUN_TARGET_NAME="simplewallet">
+  <configuration default="false" name="wallet" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--generate-new-wallet test" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$CMakeCurrentLocalGenerationDir$" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Lethean" TARGET_NAME="wallet" CONFIG_NAME="Release" RUN_TARGET_PROJECT_NAME="Lethean" RUN_TARGET_NAME="simplewallet">
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
     </method>

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -20,95 +20,38 @@
 # To build with different lib versions, pass through --build-arg's
 #   docker build --build-arg OPENSSL_VERSION_DOT=1.1.1n --build-arg OPENSSL_HASH=40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a -f utils/docker/Dockerfile .
 #
+# To adjust the threads used
+#   docker build --build-arg THREADS=10 -t chain/testnet .
+#
 # Available Build Args
+#   - Build Jobs:       THREADS=2
 #   - CMake Version:    CMAKE_VERSION_DOT, CMAKE_HASH
 #   - Boost Version:    BOOST_VERSION, BOOST_VERSION_DOT, BOOST_HASH
 #   - OpenSSL Version:  OPENSSL_VERSION_DOT, OPENSSL_HASH
 
-FROM ubuntu:20.04 as build-prep
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update
-RUN apt-get install -y build-essential libicu-dev git curl g++ libssl-dev make pkg-config libboost-all-dev \
-    zlib1g-dev mesa-common-dev libglu1-mesa-dev python-dev autotools-dev libbz2-dev cmake screen checkinstall
+FROM lthn/build:server as build
 
-WORKDIR /root
+ARG THREADS=2
 
-##########################################################
-# Split download & compile to use dockers caching layers #
-##########################################################
+COPY . /project
 
-# Download CMake
-ARG CMAKE_VERSION_DOT=3.15.5
-ARG CMAKE_HASH=62e3e7d134a257e13521e306a9d3d1181ab99af8fcae66699c8f98754fc02dda
-RUN set -ex \
-    && curl https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION_DOT}/cmake-${CMAKE_VERSION_DOT}-Linux-x86_64.sh -OL\
-    && echo "${CMAKE_HASH}  cmake-${CMAKE_VERSION_DOT}-Linux-x86_64.sh" | sha256sum -c
-
-# Download Boost
-ARG BOOST_VERSION=1_70_0
-ARG BOOST_VERSION_DOT=1.70.0
-ARG BOOST_HASH=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
-RUN set -ex \
-    && curl -L -o  boost_${BOOST_VERSION}.tar.bz2 https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION_DOT}/boost_${BOOST_VERSION}.tar.bz2 \
-    &&  sha256sum boost_${BOOST_VERSION}.tar.bz2 \
-    && echo "${BOOST_HASH}  boost_${BOOST_VERSION}.tar.bz2" | sha256sum -c\
-    && tar -xvf boost_${BOOST_VERSION}.tar.bz2
-
-
-# Download OpenSSL
-ARG OPENSSL_VERSION_DOT=1.1.1n
-ARG OPENSSL_HASH=40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
-
-RUN curl https://www.openssl.org/source/openssl-${OPENSSL_VERSION_DOT}.tar.gz -OL \
-    &&  sha256sum openssl-${OPENSSL_VERSION_DOT}.tar.gz \
-    && echo "${OPENSSL_HASH} openssl-${OPENSSL_VERSION_DOT}.tar.gz" | sha256sum -c
-
-
-# Compile CMake
-RUN set -ex \
-    && mkdir /opt/cmake \
-    && sh cmake-3.15.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license\
-    && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake\
-    && cmake --version\
-    && rm cmake-3.15.5-Linux-x86_64.sh
-
-# Compile Boost
-RUN set -ex \
-    && cd boost_${BOOST_VERSION} \
-    && ./bootstrap.sh --with-libraries=system,filesystem,thread,date_time,chrono,regex,serialization,atomic,program_options,locale,timer,log \
-    && ./b2
-ENV BOOST_ROOT /root/boost_${BOOST_VERSION}
-
-# Compile OpenSSL
-RUN set -ex \
-    && tar xaf openssl-${OPENSSL_VERSION_DOT}.tar.gz \
-    && rm openssl-${OPENSSL_VERSION_DOT}.tar.gz \
-    && cd openssl-${OPENSSL_VERSION_DOT} \
-    && ./config --prefix=/root/openssl --openssldir=/root/openssl shared zlib \
-    && make \
-    && make test \
-    && make install \
-    && cd .. \
-    && rm -rf openssl-${OPENSSL_VERSION_DOT}
-
-ENV OPENSSL_ROOT_DIR=/root/openssl
-
-FROM build-prep as build
-
-COPY . /root/lethean
-
-WORKDIR /root/lethean/build
+WORKDIR /project/build
 
 RUN cmake -D STATIC=true -D ARCH=x86-64 -D TESTNET=TRUE -D CMAKE_BUILD_TYPE=Release ..
 
-RUN make -j2 daemon simplewallet
+RUN make -j${THREADS} daemon simplewallet
 
-
+# Export stage; scratch is a empty fs you can use this image to build the assets with
+#   docker build -t chain/testnet --target export -o artifacts
 #
-# Run Lethean
-#
+# Developer builds
+#   docker run -v $(pwd):/project --target export -o artifacts lthn/chain:developer
 
-FROM ubuntu:20.04
+FROM scratch as export
+COPY --chmod=0777 --from=build /project/build/src/letheand /
+COPY --chmod=0777 --from=build /project/build/src/simplewallet /
+
+FROM ubuntu:20.04 as final
 
 RUN useradd -ms /bin/bash lethean &&\
     mkdir -p /home/lethean/data &&\
@@ -117,8 +60,8 @@ RUN useradd -ms /bin/bash lethean &&\
 USER lethean:lethean
 
 WORKDIR /home/lethean
-COPY --chmod=0777 --chown=lethean:lethean --from=build /root/lethean/build/src/letheand .
-COPY --chmod=0777 --chown=lethean:lethean --from=build /root/lethean/build/src/simplewallet .
+
+COPY --chmod=0777 --chown=lethean:lethean --from=export / .
 
 # blockchain loaction
 VOLUME /home/lethean/data
@@ -126,4 +69,4 @@ VOLUME /home/lethean/data
 EXPOSE 31121 31211
 
 ENTRYPOINT ["./letheand"]
-CMD ["--disable-upnp", "--rpc-bind-ip=0.0.0.0", "--log-level=0", "--data-dir=/home/lethean/data"]
+CMD ["--disable-upnp", "--non-interactive", "--rpc-bind-ip=0.0.0.0", "--log-level=0", "--data-dir=/home/lethean/data"]

--- a/utils/docker/docker-compose.yml
+++ b/utils/docker/docker-compose.yml
@@ -2,11 +2,14 @@ version: "3"
 services:
   server-chain:
     container_name: letheand
-    image: lthn/chain-itw3:testnet
+    build:
+      context: ../../
+      dockerfile: utils/docker/Dockerfile
+    image: lthn/chain:testnet
     platform: linux/amd64
     restart: always
     volumes:
-      - ~/Lethean/data:/root/Lethean/data
+      - ~/Lethean/data:/home/lethean/data
     ports:
       - 31121
       - 31211


### PR DESCRIPTION
* updates GHA to use githubs container reg for cache layers + publish to dockerhub
* lthn/chain-itw3 > lthn/chain:testnet
* JetBrains setting update
* updates dockerfile to use lthn/build:server vs ubuntu:20.04
* path fix for end exe's
* --non-interactive on letheand
* adds compile info to docker-compose.yml; for use with cold wallets if their local daemon is seeded with lthn/build:server no network connection is needed.
* if GHA event is a pull_request use github.head_ref